### PR TITLE
Revert "Upgrade documentation build to work with more recent version of GHC".

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,11 +69,8 @@ jobs:
           cabal build all --only-dependencies
 
       - name: Build
-        run: >
-          cabal build all
-          --enable-benchmarks
-          --enable-documentation
-          --enable-tests
+        run: |
+          cabal build all --enable-tests --enable-benchmarks
 
       - name: Test
         run: |
@@ -86,10 +83,11 @@ jobs:
       - name: Documentation
         if: |
             matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.4.2'
+            && matrix.ghc == '8.10.7'
         run: >
           cabal haddock
           --haddock-hyperlink-source
+          --haddock-quickjump
           --haddock-html-location
           'https://hackage.haskell.org/package/$pkg-$version/docs'
 
@@ -101,7 +99,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.4.2'
+            && matrix.ghc == '8.10.7'
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
           branch: gh-pages


### PR DESCRIPTION
This commit broke all hyperlinks to the `base` package in generated documentation.

This reverts commit cc4fe2802c3215d51f2a6ab69b44efbc8199c207.