### PR TITLE
Add property tests for the validity of traversal functions.

### DIFF
--- a/src/test/Data/MonoidMap/ValiditySpec.hs
+++ b/src/test/Data/MonoidMap/ValiditySpec.hs
@@ -65,7 +65,15 @@ import Test.Common
 import Test.Hspec
     ( Spec, it )
 import Test.QuickCheck
-    ( Fun, Property, applyFun, applyFun2, conjoin, counterexample, cover )
+    ( Fun
+    , Property
+    , applyFun
+    , applyFun2
+    , applyFun3
+    , conjoin
+    , counterexample
+    , cover
+    )
 
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
@@ -189,6 +197,12 @@ specValidMonoidNull = makeSpec $ do
             @k @v & property
     it "propValid_mapAccumR" $
         propValid_mapAccumR
+            @k @v & property
+    it "propValid_mapAccumLWithKey" $
+        propValid_mapAccumLWithKey
+            @k @v & property
+    it "propValid_mapAccumRWithKey" $
+        propValid_mapAccumRWithKey
             @k @v & property
     it "propValid_traverse" $
         propValid_traverse
@@ -509,6 +523,26 @@ propValid_mapAccumR
     -> Property
 propValid_mapAccumR (applyFun2 -> f) s m =
     propValid $ snd $ MonoidMap.mapAccumR f s m
+
+propValid_mapAccumLWithKey
+    :: forall k v s. s ~ Int
+    => Test k v
+    => Fun (s, k, v) (s, v)
+    -> s
+    -> MonoidMap k v
+    -> Property
+propValid_mapAccumLWithKey (applyFun3 -> f) s m =
+    propValid $ snd $ MonoidMap.mapAccumLWithKey f s m
+
+propValid_mapAccumRWithKey
+    :: forall k v s. s ~ Int
+    => Test k v
+    => Fun (s, k, v) (s, v)
+    -> s
+    -> MonoidMap k v
+    -> Property
+propValid_mapAccumRWithKey (applyFun3 -> f) s m =
+    propValid $ snd $ MonoidMap.mapAccumRWithKey f s m
 
 propValid_traverse
     :: forall k v t. (Applicative t, Foldable t, Test k v)

--- a/src/test/Data/MonoidMap/ValiditySpec.hs
+++ b/src/test/Data/MonoidMap/ValiditySpec.hs
@@ -184,6 +184,12 @@ specValidMonoidNull = makeSpec $ do
     it "propValid_mapKeysWith" $
         propValid_mapKeysWith
             @k @v & property
+    it "propValid_mapAccumL" $
+        propValid_mapAccumL
+            @k @v & property
+    it "propValid_mapAccumR" $
+        propValid_mapAccumR
+            @k @v & property
     it "propValid_traverse" $
         propValid_traverse
             @k @v & property
@@ -483,6 +489,26 @@ propValid_mapKeysWith
     :: Test k v => Fun (v, v) v -> Fun k k -> MonoidMap k v -> Property
 propValid_mapKeysWith (applyFun2 -> f) (applyFun -> g) m =
     propValid (MonoidMap.mapKeysWith f g m)
+
+propValid_mapAccumL
+    :: forall k v s. s ~ Int
+    => Test k v
+    => Fun (s, v) (s, v)
+    -> s
+    -> MonoidMap k v
+    -> Property
+propValid_mapAccumL (applyFun2 -> f) s m =
+    propValid $ snd $ MonoidMap.mapAccumL f s m
+
+propValid_mapAccumR
+    :: forall k v s. s ~ Int
+    => Test k v
+    => Fun (s, v) (s, v)
+    -> s
+    -> MonoidMap k v
+    -> Property
+propValid_mapAccumR (applyFun2 -> f) s m =
+    propValid $ snd $ MonoidMap.mapAccumR f s m
 
 propValid_traverse
     :: forall k v t. (Applicative t, Foldable t, Test k v)


### PR DESCRIPTION
This PR adds property tests for the validity of the following traversal functions:
  - `traverse`
  - `traverseWithKey`
  - `mapAccumL`
  - `mapAccumLWithKey`
  - `mapAccumR`
  - `mapAccumRWithKey`
  
In particular, we test that these functions do not inadvertently introduce non-canonical `null` values into the resultant maps.