### PR TITLE
Use unified key type in test suite.

### DIFF
--- a/components/monoidmap-test/Data/MonoidMap/ClassSpec.hs
+++ b/components/monoidmap-test/Data/MonoidMap/ClassSpec.hs
@@ -26,6 +26,8 @@ import Test.Combinators.NonZero
 import Test.Common ()
 import Test.Hspec
     ( Spec, describe )
+import Test.Key
+    ( Key1, Key2, Key4, Key8 )
 import Test.QuickCheck
     ( Arbitrary (..) )
 import Test.QuickCheck.Classes
@@ -68,12 +70,11 @@ import Test.QuickCheck.Classes.Semigroup.Cancellative
 spec :: Spec
 spec = do
     describe "Class laws" $ do
-        -- Test against a variety of key types, in ascending order of
-        -- cardinality:
-        specLawsFor (Proxy @Bool)
-        specLawsFor (Proxy @Ordering)
-        specLawsFor (Proxy @Int)
-        specLawsFor (Proxy @Integer)
+        -- Test against a variety of key sizes:
+        specLawsFor (Proxy @Key1)
+        specLawsFor (Proxy @Key2)
+        specLawsFor (Proxy @Key4)
+        specLawsFor (Proxy @Key8)
 
 specLawsFor
     :: forall k. () =>

--- a/components/monoidmap-test/Test/Common.hs
+++ b/components/monoidmap-test/Test/Common.hs
@@ -62,6 +62,8 @@ import Numeric.Natural
     ( Natural )
 import Test.Hspec
     ( Spec, describe )
+import Test.Key
+    ( Key4 )
 import Test.QuickCheck
     ( Arbitrary (..)
     , CoArbitrary (..)
@@ -70,7 +72,6 @@ import Test.QuickCheck
     , Testable
     , arbitrarySizedIntegral
     , checkCoverage
-    , choose
     , coarbitraryIntegral
     , coarbitraryShow
     , frequency
@@ -139,18 +140,7 @@ instance Function Text where
 -- Test keys
 --------------------------------------------------------------------------------
 
-newtype Key = Key Int
-    deriving (Enum, Eq, Integral, Num, Ord, Real, Show)
-
-instance Arbitrary Key where
-    arbitrary = Key <$> choose (0, 15)
-    shrink (Key k) = Key <$> shrink k
-
-instance CoArbitrary Key where
-    coarbitrary = coarbitraryIntegral
-
-instance Function Key where
-    function = functionIntegral
+type Key = Key4
 
 --------------------------------------------------------------------------------
 -- Test constraints

--- a/components/monoidmap-test/Test/Common.hs
+++ b/components/monoidmap-test/Test/Common.hs
@@ -63,7 +63,7 @@ import Numeric.Natural
 import Test.Hspec
     ( Spec, describe )
 import Test.Key
-    ( Key4 )
+    ( Key2, Key4 )
 import Test.QuickCheck
     ( Arbitrary (..)
     , CoArbitrary (..)
@@ -140,6 +140,7 @@ instance Function Text where
 -- Test keys
 --------------------------------------------------------------------------------
 
+type SmallKey = Key2
 type Key = Key4
 
 --------------------------------------------------------------------------------
@@ -188,14 +189,14 @@ testValueTypesAll =
     , TestValueType (Proxy @(Text))
     , TestValueType (Proxy @[Int])
     , TestValueType (Proxy @[Natural])
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Int)))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Int)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesGroup :: [TestValueType Group]
 testValueTypesGroup =
     [ TestValueType (Proxy @(Sum Int))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Int)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Int)))
     ]
 
 testValueTypesMonus :: [TestValueType Monus]
@@ -204,7 +205,7 @@ testValueTypesMonus =
     , TestValueType (Proxy @(Set Int))
     , TestValueType (Proxy @(Set Natural))
     , TestValueType (Proxy @(Sum Natural))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesLeftReductive :: [TestValueType LeftReductive]
@@ -221,7 +222,7 @@ testValueTypesLeftReductive =
     , TestValueType (Proxy @(Text))
     , TestValueType (Proxy @[Int])
     , TestValueType (Proxy @[Natural])
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesRightReductive :: [TestValueType RightReductive]
@@ -238,7 +239,7 @@ testValueTypesRightReductive =
     , TestValueType (Proxy @(Text))
     , TestValueType (Proxy @[Int])
     , TestValueType (Proxy @[Natural])
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesReductive :: [TestValueType Reductive]
@@ -249,7 +250,7 @@ testValueTypesReductive =
     , TestValueType (Proxy @(Set Natural))
     , TestValueType (Proxy @(Sum Int))
     , TestValueType (Proxy @(Sum Natural))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesLeftGCDMonoid :: [TestValueType LeftGCDMonoid]
@@ -260,7 +261,7 @@ testValueTypesLeftGCDMonoid =
     , TestValueType (Proxy @(Set Natural))
     , TestValueType (Proxy @(Sum Natural))
     , TestValueType (Proxy @(Text))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesRightGCDMonoid :: [TestValueType RightGCDMonoid]
@@ -271,7 +272,7 @@ testValueTypesRightGCDMonoid =
     , TestValueType (Proxy @(Set Natural))
     , TestValueType (Proxy @(Sum Natural))
     , TestValueType (Proxy @(Text))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesOverlappingGCDMonoid :: [TestValueType OverlappingGCDMonoid]
@@ -282,7 +283,7 @@ testValueTypesOverlappingGCDMonoid =
     , TestValueType (Proxy @(Set Natural))
     , TestValueType (Proxy @(Sum Natural))
     , TestValueType (Proxy @(Text))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesGCDMonoid :: [TestValueType GCDMonoid]
@@ -291,7 +292,7 @@ testValueTypesGCDMonoid =
     , TestValueType (Proxy @(Set Int))
     , TestValueType (Proxy @(Set Natural))
     , TestValueType (Proxy @(Sum Natural))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 testValueTypesLCMMonoid :: [TestValueType LCMMonoid]
@@ -300,7 +301,7 @@ testValueTypesLCMMonoid =
     , TestValueType (Proxy @(Set Int))
     , TestValueType (Proxy @(Set Natural))
     , TestValueType (Proxy @(Sum Natural))
-    , TestValueType (Proxy @(MonoidMap Ordering (Sum Natural)))
+    , TestValueType (Proxy @(MonoidMap SmallKey (Sum Natural)))
     ]
 
 --------------------------------------------------------------------------------

--- a/components/monoidmap-test/Test/Key.hs
+++ b/components/monoidmap-test/Test/Key.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+-- |
+-- Copyright: © 2022–2025 Jonathan Knowles
+-- License: Apache-2.0
+--
+-- Quasi-unique keys.
+--
+module Test.Key
+    ( Key1
+    , Key2
+    , Key4
+    , Key8
+    )
+where
+
+import Prelude
+
+import GHC.Generics
+    ( Generic
+    )
+import GHC.TypeLits
+    ( Nat
+    )
+import Test.QuickCheck
+    ( Arbitrary
+    , CoArbitrary
+    , Function
+    )
+import Test.QuickCheck.Quid
+    ( Latin (Latin)
+    , Quid
+    , Size (Size)
+    )
+
+newtype Key (size :: Nat) = Key (Latin Quid)
+    deriving stock (Eq, Generic, Ord)
+    deriving newtype (Read, Show)
+    deriving (Arbitrary) via Size size Quid
+    deriving (CoArbitrary) via Quid
+    deriving anyclass (Function)
+
+type Key1 = Key 1
+type Key2 = Key 2
+type Key4 = Key 4
+type Key8 = Key 8

--- a/monoidmap.cabal
+++ b/monoidmap.cabal
@@ -206,6 +206,7 @@ test-suite monoidmap-test
         Test.Common
         Test.QuickCheck.Classes.Hspec
         Test.Hspec.Unit
+        Test.Key
     type:
         exitcode-stdio-1.0
     default-language:

--- a/monoidmap.cabal
+++ b/monoidmap.cabal
@@ -42,6 +42,8 @@ common dependency-quickcheck-groups
     build-depends:quickcheck-groups             >= 0.0.0.0    && < 0.1
 common dependency-quickcheck-monoid-subclasses
     build-depends:quickcheck-monoid-subclasses  >= 0.3.0.0    && < 0.4
+common dependency-quickcheck-quid
+    build-depends:quickcheck-quid               >= 0.0.1.7    && < 0.1
 common dependency-tasty-bench
     build-depends:tasty-bench                   >= 0.3.2      && < 0.5
 common dependency-tasty-hunit
@@ -165,6 +167,7 @@ test-suite monoidmap-test
       , dependency-quickcheck-classes
       , dependency-quickcheck-groups
       , dependency-quickcheck-monoid-subclasses
+      , dependency-quickcheck-quid
       , dependency-text
       , extensions
     build-depends:


### PR DESCRIPTION
This PR:
- defines a new `Key` type, based on the `Quid` quasi-unique identifier type from `quickcheck-quid`;
- unifies all tests to use this key type instead of various ad-hoc key types.

The new `Key` type makes it possible to exert fine-grained control over the generated key space in a more explicit way, making it easier to tweak coverage of individual test cases.

For a given `Key (n :: Nat)`, arbitrary keys are generated uniformly from a key space of size `2 ^ n`. For example, the type `Key 8` has `2 ^ 8 = 256` possible inhabitants.

Keys are serialised as readable Latin-character strings in test failures. For example:
```
*** Failed! Falsified, Falsified (after 72 tests and 15 shrinks):
{_->False}
fromList [("G",fromList [("A",Sum {getSum = 1})])]
fromList [("G",fromList [("A",Sum {getSum = 1})])]
"G"
```
