### PR TITLE
Specify `not-home` in `Data.MonoidMap.Internal`.

### DIFF
--- a/components/monoidmap-internal/Data/MonoidMap/Internal.hs
+++ b/components/monoidmap-internal/Data/MonoidMap/Internal.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# OPTIONS_HADDOCK not-home #-}
 {- HLINT ignore "Avoid lambda" -}
 {- HLINT ignore "Avoid lambda using `infix`" -}
 {- HLINT ignore "Redundant bracket" -}


### PR DESCRIPTION
For the purposes of public API documentation, we want to arrange that `haddock` will not treat `Data.MonoidMap.Internal` as a home module for functions and types re-exported from `Data.MonoidMap`.