### PR TITLE
Drop dependency on `nonempty-containers`.

### DIFF
--- a/components/monoidmap-examples/Data/Set/NonEmpty.hs
+++ b/components/monoidmap-examples/Data/Set/NonEmpty.hs
@@ -1,0 +1,44 @@
+-- |
+-- Copyright: © 2022–2025 Jonathan Knowles
+-- License: Apache-2.0
+--
+-- A minimal non-empty variant of the 'Set' data type.
+--
+module Data.Set.NonEmpty
+    ( NESet
+    , nonEmptySet
+    , toSet
+    , isSubsetOf
+    , union
+    , intersection
+    ) where
+
+import Prelude
+
+import Data.Coerce
+    ( coerce )
+import Data.Set
+    ( Set )
+
+import qualified Data.Set as Set
+
+newtype NESet v = NESet (Set v)
+    deriving stock Eq
+    deriving newtype (Semigroup, Show)
+
+nonEmptySet :: Set v -> Maybe (NESet v)
+nonEmptySet s
+    | Set.null s = Nothing
+    | otherwise = Just (NESet s)
+
+toSet :: NESet v -> Set v
+toSet = coerce
+
+isSubsetOf :: Ord v => NESet v -> NESet v -> Bool
+isSubsetOf = coerce Set.isSubsetOf
+
+union :: Ord v => NESet v -> NESet v -> NESet v
+union = coerce Set.union
+
+intersection :: Ord v => NESet v -> NESet v -> Set v
+intersection = coerce Set.intersection

--- a/monoidmap.cabal
+++ b/monoidmap.cabal
@@ -28,8 +28,6 @@ common dependency-hspec
     build-depends:hspec                         >= 2.10.9     && < 2.12
 common dependency-monoid-subclasses
     build-depends:monoid-subclasses             >= 1.2.3      && < 1.3
-common dependency-nonempty-containers
-    build-depends:nonempty-containers           >= 0.3.4.4    && < 0.4
 common dependency-nothunks
     build-depends:nothunks                      >= 0.1.3      && < 0.4
 common dependency-pretty-show
@@ -117,7 +115,6 @@ library monoidmap-examples
       , dependency-containers
       , dependency-deepseq
       , dependency-monoid-subclasses
-      , dependency-nonempty-containers
       , extensions
     build-depends:
       , monoidmap
@@ -126,6 +123,7 @@ library monoidmap-examples
     hs-source-dirs:
         components/monoidmap-examples
     exposed-modules:
+        Data.Set.NonEmpty
         Examples.MultiMap
         Examples.MultiMap.Class
         Examples.MultiMap.Instances.MultiMap1


### PR DESCRIPTION
This PR adds a minimal non-empty variant of the `Set` data type, allowing us to drop the dependency on `nonempty-containers`.